### PR TITLE
fix: respect live debug toggle in 1.19 handler and mitigate reload li…

### DIFF
--- a/src/com/github/joelgodofwar/sr/ShulkerRespawner.java
+++ b/src/com/github/joelgodofwar/sr/ShulkerRespawner.java
@@ -29,6 +29,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Shulker;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -816,6 +817,9 @@ public class ShulkerRespawner  extends JavaPlugin implements Listener{
 			debug = true;
 			LOGGER.log("jarfile contains -DEV, debug set to true.");
 		}
+
+		HandlerList.unregisterAll(this);
+		getServer().getPluginManager().registerEvents(this, this);
 
 		String packageName = this.getServer().getClass().getPackage().getName();
 		String version = packageName.substring(packageName.lastIndexOf('.') + 2);

--- a/src/com/github/joelgodofwar/sr/events/CSEHandler_1_19.java
+++ b/src/com/github/joelgodofwar/sr/events/CSEHandler_1_19.java
@@ -40,11 +40,9 @@ import com.github.joelgodofwar.sr.common.error.Report;
 @SuppressWarnings("static-access")
 public class CSEHandler_1_19 implements Listener {
 	ShulkerRespawner SR;
-	boolean debug;
 
 	public CSEHandler_1_19(final ShulkerRespawner plugin){
 		SR = plugin;
-		debug = plugin.debug;
 	}
 
 	@EventHandler
@@ -80,7 +78,7 @@ public class CSEHandler_1_19 implements Listener {
 							String packageName = SR.getServer().getClass().getPackage().getName();
 							String version = packageName.substring(packageName.lastIndexOf('.') + 2);
 
-							boolean result = ShulkerRespawnerLib.playerInsideStructure(entity, version, debug);
+							boolean result = ShulkerRespawnerLib.playerInsideStructure(entity, version, SR.debug);
 							SR.LOGGER.debug("result=" + result);
 							if(!result) {
 								SR.LOGGER.debug("Enderman is not in an EndCity.");


### PR DESCRIPTION
## What changed
- removed cached debug state from CSEHandler_1_19
- switched structure check to use the live plugin debug value
- unregisters plugin listeners before re-registering on reload

## Why
`/sr toggledebug` was not fully respected because the 1.19 handler cached the debug value at construction time. Reloads could also stack listeners and worsen console spam.

## Scope
Minimal surgical fix only. Mitigates listener stacking on reload; no broader refactor.